### PR TITLE
Render refractor

### DIFF
--- a/Game/Source/App.h
+++ b/Game/Source/App.h
@@ -52,15 +52,26 @@ public:
 	// Exposing some properties for reading
 	int GetArgc() const;
 	const char* GetArgv(int index) const;
+
+	// Getters
 	std::string GetTitle() const;
 	std::string GetOrganization() const;
+	uint GetLevelNumber() const;
 	
+	// Saving / Loading
 	void LoadGameRequest();
 	void SaveGameRequest();
 	bool LoadFromFile();
 	bool SaveToFile();
+	bool SaveAttributeToConfig(
+		std::string const &moduleName, 
+		std::string const &node, 
+		std::string const &attribute, 
+		std::string const &value
+	);
 	
-	uint GetLevelNumber() const;
+	// Utils
+	bool PauseGame() const;
 
 	// Modules
 	std::unique_ptr<Window> win;

--- a/Game/Source/Character.cpp
+++ b/Game/Source/Character.cpp
@@ -40,15 +40,15 @@ bool Character::Start()
 bool Character::Update()
 {
 	/*
-	//Update Character position in pixels
-	position.x = METERS_TO_PIXELS(pBody->body->GetTransform().p.x) - Character_SIZE/2;
-	position.y = METERS_TO_PIXELS(pBody->body->GetTransform().p.y) - Character_SIZE/2;
+	Update Character position in pixels
+	position.x = METERS_TO_PIXELS(pBody->body->GetTransform().p.x) - Character_SIZE/2
+	position.y = METERS_TO_PIXELS(pBody->body->GetTransform().p.y) - Character_SIZE/2
 
-	app->render->DrawTexture(texture->UpdateAndGetFrame(), position.x, position.y);
+	app->render->DrawTexture(texture->UpdateAndGetFrame(), position.x, position.y)
 
-	for(int i = 0; i < hp; i++)
+	forint i = 0; i < hp; i++)
 	{
-		app->render->DrawTexture(texture->UpdateAndGetFrame(), 710, 930 - i*(Character_SIZE + 10));
+		app->render->DrawTexture(texture->UpdateAndGetFrame(), 710, 930 - i*(Character_SIZE + 10))
 	}*/
 
 	return true;

--- a/Game/Source/Fonts.cpp
+++ b/Game/Source/Fonts.cpp
@@ -185,12 +185,7 @@ void Fonts::Draw(std::string_view text, iPoint position, int fontId, bool isFixe
 			
 			xAdvance += it->second.xAdvance + 2;
 
-			if(!newLine)
-			{
-				newLine = CheckIfNewLine(position.x, xAdvance, maxX, i);
-				if(maxX.first == NUMBER_OF_CHARS);
-			}
-
+			if(!newLine) newLine = CheckIfNewLine(position.x, xAdvance, maxX, i);
 		}
 		else LOG("Character %s could not be found in %s", elem, font.name.c_str());
 	}

--- a/Game/Source/Physics.cpp
+++ b/Game/Source/Physics.cpp
@@ -108,21 +108,21 @@ bool Physics::PostUpdate()
 				{
 					auto const *circleShape = dynamic_cast<b2CircleShape *>(f->GetShape());
 					b2Vec2 pos = f->GetBody()->GetPosition() + circleShape->m_p;
-					app->render->DrawCircle(METERS_TO_PIXELS(pos.x), METERS_TO_PIXELS(pos.y), METERS_TO_PIXELS(circleShape->m_radius), 255, 255, 255);
+					app->render->DrawCircle(METERS_TO_PIXELS(pos), METERS_TO_PIXELS(circleShape->m_radius), SDL_Color(255,255,255,255));
 					break;
 				}
 				// Draw polygons ------------------------------------------------
 				case b2Shape::Type::e_polygon:
 				{
 					auto const *itemToDraw = dynamic_cast<b2PolygonShape *>(f->GetShape());
-					DrawDebug(b, itemToDraw->m_count, itemToDraw->m_vertices, 255, 255, 0);
+					DrawDebug(b, itemToDraw->m_count, itemToDraw->m_vertices, SDL_Color(255, 255, 0, 255));
 					break;
 				}
 				// Draw chains contour -------------------------------------------
 				case b2Shape::Type::e_chain:
 				{
 					auto const *itemToDraw = dynamic_cast<b2ChainShape *>(f->GetShape());
-					DrawDebug(b, itemToDraw->m_count, itemToDraw->m_vertices, 100, 255, 100);
+					DrawDebug(b, itemToDraw->m_count, itemToDraw->m_vertices, SDL_Color(100, 255, 100, 255));
 					break;
 				}
 				// Draw a single segment(edge) ----------------------------------
@@ -132,7 +132,7 @@ bool Physics::PostUpdate()
 					b2Vec2 v1 = b->GetWorldPoint(edgeShape->m_vertex0);
 					b2Vec2 v2 = b->GetWorldPoint(edgeShape->m_vertex1);
 
-					app->render->DrawLine(METERS_TO_PIXELS(v1.x), METERS_TO_PIXELS(v1.y), METERS_TO_PIXELS(v2.x), METERS_TO_PIXELS(v2.y), 100, 100, 255);
+					app->render->DrawLine(METERS_TO_PIXELS(v1), METERS_TO_PIXELS(v2), SDL_Color(100, 100, 255, 255));
 					break;
 				}
 				case b2Shape::Type::e_typeCount:
@@ -363,22 +363,21 @@ b2MouseJoint *Physics::CreateMouseJoint(b2Body *origin, b2Body *target, b2Vec2 p
 
 void Physics::DragSelectedObject()
 {
-	int mouseX;
-	int mouseY;
-	app->input->GetMousePosition(mouseX, mouseY);
-	b2Vec2 target(PIXEL_TO_METERS(mouseX), PIXEL_TO_METERS(mouseY));
-
 	switch (app->input->GetMouseButtonDown(SDL_BUTTON_LEFT))
 	{
 		case KeyState::KEY_DOWN:
 		{
-			mouseJoint = CreateMouseJoint(ground, selected, target);
+			mouseJoint = CreateMouseJoint(ground, selected, PIXEL_TO_METERS(app->input->GetMousePosition()));
 			break;
 		}
 		case KeyState::KEY_REPEAT:
 		{
-			mouseJoint->SetTarget(target);
-			app->render->DrawLine(mouseX, mouseY, METERS_TO_PIXELS(selected->GetPosition().x), METERS_TO_PIXELS(selected->GetPosition().y), 0, 255, 255, 255);
+			mouseJoint->SetTarget(PIXEL_TO_METERS(app->input->GetMousePosition()));
+			app->render->DrawLine(
+				app->input->GetMousePosition(),
+				METERS_TO_PIXELS(selected->GetPosition()),
+				SDL_Color(0, 255, 255, 255)
+			);
 			break;
 		}
 		case KeyState::KEY_UP:
@@ -404,7 +403,7 @@ void Physics::DestroyMouseJoint()
 //--------------- Utils
 
 //---- Debug
-void Physics::DrawDebug(const b2Body *body, const int32 count, const b2Vec2 *vertices, Uint8 r, Uint8 g, Uint8 b, Uint8 a) const
+void Physics::DrawDebug(const b2Body *body, const int32 count, const b2Vec2 *vertices, SDL_Color color) const
 {
 	b2Vec2 prev = body->GetWorldPoint(vertices[0]);
 	b2Vec2 v;
@@ -412,12 +411,12 @@ void Physics::DrawDebug(const b2Body *body, const int32 count, const b2Vec2 *ver
 	for (int32 i = 1; i < count; ++i)
 	{
 		v = body->GetWorldPoint(vertices[i]);
-		app->render->DrawLine(METERS_TO_PIXELS(prev.x), METERS_TO_PIXELS(prev.y), METERS_TO_PIXELS(v.x), METERS_TO_PIXELS(v.y), r, g, b, a);
+		app->render->DrawLine(METERS_TO_PIXELS(prev), METERS_TO_PIXELS(v), color);
 		prev = v;
 	}
 
 	v = body->GetWorldPoint(vertices[0]);
-	app->render->DrawLine(METERS_TO_PIXELS(prev.x), METERS_TO_PIXELS(prev.y), METERS_TO_PIXELS(v.x), METERS_TO_PIXELS(v.y), r, g, b, a);
+	app->render->DrawLine(METERS_TO_PIXELS(prev), METERS_TO_PIXELS(v), color);
 }
 
 bool Physics::IsMouseOverObject(b2Fixture const *f) const

--- a/Game/Source/Physics.h
+++ b/Game/Source/Physics.h
@@ -33,6 +33,23 @@ constexpr int METERS_TO_PIXELS(T m)
 	return static_cast<int>(std::floor(PIXELS_PER_METER * m));
 }
 
+template<typename T>
+concept PointToInt = requires (T t) 
+{ 
+	{ t.x } -> std::convertible_to<int>;
+	{ t.y } -> std::convertible_to<int>;
+};
+
+template<PointToInt T = b2Vec2>
+constexpr iPoint METERS_TO_PIXELS(T p)
+{
+	iPoint r = {
+		static_cast<int>(std::floor(PIXELS_PER_METER * p.x)),
+		static_cast<int>(std::floor(PIXELS_PER_METER * p.y))
+	};
+	return r;
+}
+
 // Box2D -> Screen
 constexpr auto METER_PER_PIXEL = 1.0f/PIXELS_PER_METER;
 
@@ -41,6 +58,24 @@ constexpr float PIXEL_TO_METERS(T p)
 {
 	return static_cast<float>(p) * METER_PER_PIXEL;
 }
+
+template<typename T>
+concept PointToFloat = requires (T t)
+{
+	{ t.x } -> std::convertible_to<float>;
+	{ t.y } -> std::convertible_to<float>;
+};
+
+template<PointToFloat T = iPoint>
+constexpr b2Vec2 PIXEL_TO_METERS(T p)
+{
+	b2Vec2 r = {
+		static_cast<float>(p.x) * METER_PER_PIXEL,
+		static_cast<float>(p.y) * METER_PER_PIXEL
+	};
+	return r;
+}
+
 
 // Angles
 constexpr auto DEGTORAD = 0.0174532925199432957f;
@@ -292,7 +327,12 @@ public:
 private:
 
 	//---- Debug
-	void DrawDebug(const b2Body *body, const int32 count, const b2Vec2 *vertices, Uint8 r, Uint8 g, Uint8 b, Uint8 a = (Uint8)255U) const;
+	void DrawDebug(
+		const b2Body *body,
+		const int32 count,
+		const b2Vec2 *vertices,
+		SDL_Color color
+	) const;
 
 	//---- Joints
 	void DragSelectedObject();

--- a/Game/Source/Player.cpp
+++ b/Game/Source/Player.cpp
@@ -145,27 +145,18 @@ bool Player::Update()
 		texture->GetFlipPivot()
 	);
 
-	//Update player position in pixels
-	//position.x += METERS_TO_PIXELS(pBody->body->GetTransform().p.x) - colliderOffset.x;
-	//position.y += METERS_TO_PIXELS(pBody->body->GetTransform().p.y) - colliderOffset.y;
-	/*app->render->DrawCharacterTexture(
-		texture->UpdateAndGetFrame(),
-		position,
-		(bool)dir,
-		textureOffset,
-		colliderOffset
-	);*/
+	SDL_Rect camera = app->render->GetCamera();
 	
-	if(moveCamera && app->render->camera.x <= 0 && position.x >= startingPosition.x)
+	if(moveCamera && camera.x <= 0 && position.x >= startingPosition.x)
 	{
-		if(abs(app->render->camera.x) + cameraXCorrection <= app->map->GetWidth() * app->map->GetTileWidth())
+		if(abs(camera.x) + cameraXCorrection <= app->map->GetWidth() * app->map->GetTileWidth())
 		{
-			app->render->camera.x -= (int)(vel.x * 0.98);
-			if(app->render->camera.x > 0) app->render->camera.x = 0;
+			camera.x -= (int)(vel.x * 0.98);
+			if(camera.x > 0) camera.x = 0;
 		}
 		else if(vel.x < 0)
 		{
-			app->render->camera.x -= (int)(vel.x * 0.98);
+			camera.x -= (int)(vel.x * 0.98);
 		}
 	}
 	return true;

--- a/Game/Source/Point.h
+++ b/Game/Source/Point.h
@@ -42,6 +42,16 @@ public:
 		return r;
 	}
 
+	Point operator *(uint i)
+	{
+		Point r;
+
+		r.x = x * i;
+		r.y = y * i;
+
+		return r;
+	}
+
 	const Point& operator -=(const Point &v)
 	{
 		x -= v.x;

--- a/Game/Source/Render.cpp
+++ b/Game/Source/Render.cpp
@@ -2,6 +2,7 @@
 #include "Window.h"
 #include "Render.h"
 #include "EntityManager.h"
+#include "Input.h"
 
 #include "Defs.h"
 #include "Log.h"
@@ -9,6 +10,9 @@
 #include <iostream>
 #include <string>
 #include <array>
+
+constexpr auto ticks_for_next_frame = (1000 / 60);
+constexpr auto fps_UI_seconds_interval = 1.0f;
 
 Render::Render() : Module()
 {
@@ -29,26 +33,36 @@ bool Render::Awake(pugi::xml_node& config)
 
 	Uint32 flags = SDL_RENDERER_ACCELERATED;
 
-	if (vSyncActive = config.child("vsync").attribute("value").as_bool(true); vSyncActive)
+	if (vSyncActive = config.child("vsync").attribute("value").as_bool(); 
+		vSyncActive)
 	{
 		flags |= SDL_RENDERER_PRESENTVSYNC;
 		LOG("Using vsync");
 	}
 
-	renderer = SDL_CreateRenderer(app->win->GetWindow(), -1, flags);
+	vSyncOnRestart = vSyncActive;
 
-	if(renderer)
-	{
-		camera.w = app->win->GetSurface()->w;
-		camera.h = app->win->GetSurface()->h;
-		camera.x = 0;
-		camera.y = 0;
-	}
-	else
+	std::unique_ptr<SDL_Renderer, std::function<void(SDL_Renderer *)>>renderPtr(
+		SDL_CreateRenderer(app->win->GetWindow(), -1, flags),
+		[](SDL_Renderer *r) { if(r) SDL_DestroyRenderer(r); }
+	);
+	
+	renderer = std::move(renderPtr);
+		
+	if(!renderer)
 	{
 		LOG("Could not create the renderer! SDL_Error: %s\n", SDL_GetError());
 		return false;
 	}
+
+	camera = {
+			.x = 0,
+			.y = 0,
+			.w = app->win->GetSurface()->w,
+			.h = app->win->GetSurface()->h
+		};
+	
+	ticksForNextFrame = 1000/fpsTarget;
 
 	return true;
 }
@@ -57,27 +71,66 @@ bool Render::Awake(pugi::xml_node& config)
 bool Render::Start()
 {
 	LOG("render start");
-	// back background
-	SDL_RenderGetViewport(renderer, &viewport);
+	// Background
+	SDL_RenderGetViewport(renderer.get(), &viewport);
 	return true;
 }
 
 // Called each loop iteration
 bool Render::PreUpdate()
 {
-	SDL_RenderClear(renderer);
+	if(!vSyncActive)
+	{
+		while(SDL_GetTicks() - renderLastTime < ticksForNextFrame)
+		{
+			SDL_Delay(1);
+		}
+	}
+	
+	SDL_RenderClear(renderer.get());
 	return true;
 }
 
 bool Render::Update(float dt)
 {
+	if(app->input->GetKey(SDL_SCANCODE_V) == KEY_DOWN)
+	{
+		vSyncOnRestart = !vSyncOnRestart;
+	}
 	return true;
 }
 
 bool Render::PostUpdate()
 {
-	SDL_SetRenderDrawColor(renderer, background.r, background.g, background.g, background.a);
-	SDL_RenderPresent(renderer);
+	SDL_SetRenderDrawColor(renderer.get(),
+						   background.r,
+						   background.g,
+						   background.g,
+						   background.a
+	);
+	
+	SDL_RenderPresent(renderer.get());
+	
+	// I -> increases fps target || O ->decreases fps target
+	if(app->input->GetKey(SDL_SCANCODE_I) == KEY_DOWN && fpsTarget < 1000)
+	{
+		fpsTarget += 10;
+		ticksForNextFrame = 1000/fpsTarget;
+	}
+	if(app->input->GetKey(SDL_SCANCODE_K) == KEY_DOWN && fpsTarget > 10)
+	{
+		fpsTarget -= 10;
+		ticksForNextFrame = 1000/fpsTarget;
+	}
+	
+	if(!vSyncActive) renderLastTime = SDL_GetTicks();
+	
+	fpsTimer++;
+	if(SDL_GetTicks() - fpsTimer > static_cast<uint32>(fps_UI_seconds_interval * 1000))
+	{
+		fps = fpsTimer;
+		fpsTimer = SDL_GetTicks();
+	}
 	return true;
 }
 
@@ -85,7 +138,6 @@ bool Render::PostUpdate()
 bool Render::CleanUp()
 {
 	LOG("Destroying SDL render");
-	if(renderer) SDL_DestroyRenderer(renderer);
 	return true;
 }
 
@@ -94,17 +146,17 @@ void Render::SetBackgroundColor(SDL_Color color)
 	background = color;
 }
 
-void Render::SetViewPort(const SDL_Rect& rect)
+void Render::SetViewPort(const SDL_Rect& rect) const
 {
-	SDL_RenderSetViewport(renderer, &rect);
+	SDL_RenderSetViewport(renderer.get(), &rect);
 }
 
-void Render::ResetViewPort()
+void Render::ResetViewPort() const
 {
-	SDL_RenderSetViewport(renderer, &viewport);
+	SDL_RenderSetViewport(renderer.get(), &viewport);
 }
 
-bool Render::DrawCharacterTexture(SDL_Texture *texture, iPoint const &pos, const bool flip, SDL_Point pivot, const iPoint offset, const double angle)
+bool Render::DrawCharacterTexture(SDL_Texture *texture, iPoint const &pos, const bool flip, SDL_Point pivot, const iPoint offset, const double angle) const
 {
 	SDL_Rect rect{0};
 
@@ -132,7 +184,7 @@ bool Render::DrawCharacterTexture(SDL_Texture *texture, iPoint const &pos, const
 		p = &sdlPivot;
 	}
 		
-	if(SDL_RenderCopyEx(renderer, texture, nullptr, &rect, angle, p, (SDL_RendererFlip)flip) == -1)
+	if(SDL_RenderCopyEx(renderer.get(), texture, nullptr, &rect, angle, p, (SDL_RendererFlip)flip) == -1)
 	{
 		LOG("Cannot blit to screen. SDL_RenderCopy error: %s", SDL_GetError());
 		return false;
@@ -174,7 +226,7 @@ bool Render::DrawTexture(SDL_Texture* texture, int x, int y, const SDL_Rect* sec
 		p = &pivot;
 	}
 
-	if(SDL_RenderCopyEx(renderer, texture, section, &rect, angle, p, flip) != 0)
+	if(SDL_RenderCopyEx(renderer.get(), texture, section, &rect, angle, p, flip) != 0)
 	{
 		LOG("Cannot blit to screen. SDL_RenderCopy error: %s", SDL_GetError());
 		return false;
@@ -183,32 +235,32 @@ bool Render::DrawTexture(SDL_Texture* texture, int x, int y, const SDL_Rect* sec
 	return true;
 }
 
-bool Render::DrawRectangle(const SDL_Rect& rect, Uint8 r, Uint8 g, Uint8 b, Uint8 a, bool filled, bool use_camera) const
+bool Render::DrawRectangle(const SDL_Rect& rect, SDL_Color color, bool filled, bool use_camera, SDL_BlendMode blendMode) const
 {
-	bool ret = true;
-	uint scale = app->win->GetScale();
-
-	SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
-	SDL_SetRenderDrawColor(renderer, r, g, b, a);
+	SDL_SetRenderDrawBlendMode(renderer.get(), blendMode);
+	SDL_SetRenderDrawColor(renderer.get(), color.r, color.g, color.b, color.a);
 
 	SDL_Rect rec(rect);
+	
 	if(use_camera)
-	{
+	{	
+		uint scale = app->win->GetScale();
 		rec.x = (int)(camera.x + rect.x * scale);
 		rec.y = (int)(camera.y + rect.y * scale);
 		rec.w *= scale;
 		rec.h *= scale;
 	}
 
-	int result = filled ? SDL_RenderFillRect(renderer, &rec) : SDL_RenderDrawRect(renderer, &rec);
+	
 
-	if(result != 0)
+	if(int result = filled ? SDL_RenderFillRect(renderer.get(), &rec) : SDL_RenderDrawRect(renderer.get(), &rec); 
+	   result)
 	{
 		LOG("Cannot draw quad to screen. SDL_RenderFillRect error: %s", SDL_GetError());
-		ret = false;
+		return false;
 	}
 
-	return ret;
+	return true;
 }
 
 bool Render::DrawLine(int x1, int y1, int x2, int y2, Uint8 r, Uint8 g, Uint8 b, Uint8 a, bool use_camera) const
@@ -216,15 +268,15 @@ bool Render::DrawLine(int x1, int y1, int x2, int y2, Uint8 r, Uint8 g, Uint8 b,
 	bool ret = true;
 	uint scale = app->win->GetScale();
 
-	SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
-	SDL_SetRenderDrawColor(renderer, r, g, b, a);
+	SDL_SetRenderDrawBlendMode(renderer.get(), SDL_BLENDMODE_BLEND);
+	SDL_SetRenderDrawColor(renderer.get(), r, g, b, a);
 
 	int result = -1;
 
 	if(use_camera)
-		result = SDL_RenderDrawLine(renderer, camera.x + x1 * scale, camera.y + y1 * scale, camera.x + x2 * scale, camera.y + y2 * scale);
+		result = SDL_RenderDrawLine(renderer.get(), camera.x + x1 * scale, camera.y + y1 * scale, camera.x + x2 * scale, camera.y + y2 * scale);
 	else
-		result = SDL_RenderDrawLine(renderer, x1 * scale, y1 * scale, x2 * scale, y2 * scale);
+		result = SDL_RenderDrawLine(renderer.get(), x1 * scale, y1 * scale, x2 * scale, y2 * scale);
 
 	if(result != 0)
 	{
@@ -240,8 +292,8 @@ bool Render::DrawCircle(int x, int y, int radius, Uint8 r, Uint8 g, Uint8 b, Uin
 	bool ret = true;
 	[[maybe_unused]] uint scale = app->win->GetScale();
 
-	SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
-	SDL_SetRenderDrawColor(renderer, r, g, b, a);
+	SDL_SetRenderDrawBlendMode(renderer.get(), SDL_BLENDMODE_BLEND);
+	SDL_SetRenderDrawColor(renderer.get(), r, g, b, a);
 
 	int result = -1;
 	std::array<SDL_Point, 360> points{};
@@ -254,7 +306,7 @@ bool Render::DrawCircle(int x, int y, int radius, Uint8 r, Uint8 g, Uint8 b, Uin
 		points[i].y = camera.y + y + (int)((float)radius * sin((float)i * factor));
 	}
 
-	result = SDL_RenderDrawPoints(renderer, points.data(), 360);
+	result = SDL_RenderDrawPoints(renderer.get(), points.data(), 360);
 
 	if(result != 0)
 	{
@@ -265,8 +317,6 @@ bool Render::DrawCircle(int x, int y, int radius, Uint8 r, Uint8 g, Uint8 b, Uin
 	return ret;
 }
 
-// L03: DONE 6: Implement a method to load the state
-// for now load camera's x and y
 bool Render::LoadState(pugi::xml_node const &data)
 {
 	camera.x = data.child("camera").attribute("x").as_int();
@@ -291,7 +341,6 @@ pugi::xml_node Render::SaveState(pugi::xml_node const &data) const
 	
 
 	return cam;
-
 }
 
 bool Render::HasSaveData() const

--- a/Game/Source/Render.cpp
+++ b/Game/Source/Render.cpp
@@ -17,7 +17,7 @@ constexpr auto fps_UI_seconds_interval = 1.0f;
 
 Render::Render() : Module()
 {
-	name = "renderer";
+	name = "render";
 	background.r = 0;
 	background.g = 0;
 	background.b = 0;
@@ -97,7 +97,21 @@ bool Render::Update(float dt)
 	if(app->input->GetKey(SDL_SCANCODE_V) == KEY_DOWN)
 	{
 		vSyncOnRestart = !vSyncOnRestart;
+		app->SaveAttributeToConfig(name, "vsync", "value", vSyncOnRestart ? "true" : "false");
 	}
+
+	if(app->input->GetKey(SDL_SCANCODE_UP) == KEY_REPEAT)
+		camera.y += 1;
+
+	if(app->input->GetKey(SDL_SCANCODE_DOWN) == KEY_REPEAT)
+		camera.y -= 1;
+
+	if(app->input->GetKey(SDL_SCANCODE_LEFT) == KEY_REPEAT)
+		camera.x += 1;
+
+	if(app->input->GetKey(SDL_SCANCODE_RIGHT) == KEY_REPEAT)
+		camera.x -= 1;
+
 	return true;
 }
 
@@ -345,4 +359,18 @@ pugi::xml_node Render::SaveState(pugi::xml_node const &data) const
 bool Render::HasSaveData() const
 {
 	return true;
+}
+
+std::unique_ptr<SDL_Texture, std::function<void(SDL_Texture *)>> Render::LoadTexture(SDL_Surface *surface)
+{
+	std::unique_ptr<SDL_Texture, std::function<void(SDL_Texture *)>>texturePtr(
+			SDL_CreateTextureFromSurface(renderer.get(), surface),
+			[](SDL_Texture *tex) { if(tex) SDL_DestroyTexture(tex); }
+	);
+	return texturePtr;
+}
+
+SDL_Rect Render::GetCamera() const
+{
+	return camera;
 }

--- a/Game/Source/Render.h
+++ b/Game/Source/Render.h
@@ -20,7 +20,7 @@ public:
 	~Render() final;
 
 	// Called before render is available
-	bool Awake(pugi::xml_node&) final;
+	bool Awake(pugi::xml_node &) final;
 
 	// Called before the first frame
 	bool Start() final;
@@ -33,22 +33,22 @@ public:
 	// Called before quitting
 	bool CleanUp() final;
 
-	void SetViewPort(const SDL_Rect& rect) const;
+	void SetViewPort(const SDL_Rect &rect) const;
 	void ResetViewPort() const;
 
 	// Drawing
 	bool DrawTexture(
-		SDL_Texture* texture,
+		SDL_Texture *texture,
 		int x,
 		int y,
-		const SDL_Rect* section = nullptr,
+		const SDL_Rect *section = nullptr,
 		float speed = 1.0f,
 		double angle = 0,
 		int pivotX = INT_MAX,
 		int pivotY = INT_MAX,
 		SDL_RendererFlip flip = SDL_FLIP_NONE
 	) const;
-	
+
 	bool DrawCharacterTexture(
 		SDL_Texture *texture,
 		iPoint const &pos,
@@ -59,33 +59,27 @@ public:
 	) const;
 
 	bool DrawRectangle(
-		const SDL_Rect& rect,
+		const SDL_Rect &rect,
 		SDL_Color color,
 		bool filled = true,
-		bool useCamera = true, 
+		bool useCamera = true,
 		SDL_BlendMode blendMode = SDL_BlendMode::SDL_BLENDMODE_BLEND
 	) const;
-	
+
 	bool DrawLine(
-		int x1,
-		int y1,
-		int x2,
-		int y2,
-		Uint8 r,
-		Uint8 g,
-		Uint8 b,
-		Uint8 a = 255,
-		bool useCamera = true
+		iPoint v1,
+		iPoint v2,
+		SDL_Color color,
+		bool use_camera = true,
+		SDL_BlendMode blendMode = SDL_BlendMode::SDL_BLENDMODE_BLEND
 	) const;
-	
+
 	bool DrawCircle(
-		int x1,
-		int y1,
-		int redius,
-		Uint8 r,
-		Uint8 g,
-		Uint8 b,
-		Uint8 a = 255
+		iPoint center,
+		int radius,
+		SDL_Color color,
+		bool use_camera = true,
+		SDL_BlendMode blendMode = SDL_BlendMode::SDL_BLENDMODE_BLEND
 	) const;
 
 	// Set background color
@@ -96,12 +90,15 @@ public:
 
 	bool HasSaveData() const final;
 
+	
+
 	std::unique_ptr<SDL_Renderer, std::function<void(SDL_Renderer *)>> renderer;
 	SDL_Rect camera;
 	SDL_Rect viewport;
 	SDL_Color background;
 	
 private:
+	
 	// Max fps we want to achieve
 	uint32 fpsTarget = 60;
 	
@@ -117,6 +114,7 @@ private:
 	// Last tick in which we updated the current fps
 	uint32 fpsTimer = 0;
 
+	// -------- Vsync
 	bool vSyncActive = true;
 	bool vSyncOnRestart = true;
 };

--- a/Game/Source/Render.h
+++ b/Game/Source/Render.h
@@ -33,9 +33,6 @@ public:
 	// Called before quitting
 	bool CleanUp() final;
 
-	void SetViewPort(const SDL_Rect &rect) const;
-	void ResetViewPort() const;
-
 	// Drawing
 	bool DrawTexture(
 		SDL_Texture *texture,
@@ -90,15 +87,25 @@ public:
 
 	bool HasSaveData() const final;
 
-	
+	std::unique_ptr<SDL_Texture, std::function<void(SDL_Texture *)>> LoadTexture(SDL_Surface *surface);
+
+	SDL_Rect GetCamera() const;
+
+private:
+
+	void SetViewPort(const SDL_Rect &rect) const;
+	void ResetViewPort() const;
 
 	std::unique_ptr<SDL_Renderer, std::function<void(SDL_Renderer *)>> renderer;
 	SDL_Rect camera;
 	SDL_Rect viewport;
 	SDL_Color background;
-	
-private:
-	
+
+	// -------- Vsync
+	bool vSyncActive = true;
+	bool vSyncOnRestart = true;
+
+	// -------- No Vsync
 	// Max fps we want to achieve
 	uint32 fpsTarget = 60;
 	
@@ -113,10 +120,6 @@ private:
 	uint32 fps = 0;
 	// Last tick in which we updated the current fps
 	uint32 fpsTimer = 0;
-
-	// -------- Vsync
-	bool vSyncActive = true;
-	bool vSyncOnRestart = true;
 };
 
 #endif // __RENDER_H__

--- a/Game/Source/Scene.cpp
+++ b/Game/Source/Scene.cpp
@@ -76,18 +76,6 @@ bool Scene::Update(float dt)
 	if (app->input->GetKey(SDL_SCANCODE_F6) == KEY_DOWN)
 		app->LoadGameRequest();
 
-	if (app->input->GetKey(SDL_SCANCODE_UP) == KEY_REPEAT)
-		app->render->camera.y += 1;
-
-	if (app->input->GetKey(SDL_SCANCODE_DOWN) == KEY_REPEAT)
-		app->render->camera.y -= 1;
-
-	if (app->input->GetKey(SDL_SCANCODE_LEFT) == KEY_REPEAT)
-		app->render->camera.x += 1;
-
-	if (app->input->GetKey(SDL_SCANCODE_RIGHT) == KEY_REPEAT)
-		app->render->camera.x -= 1;
-
 	// Draw map
 	app->map->Draw();
 	

--- a/Game/Source/Textures.cpp
+++ b/Game/Source/Textures.cpp
@@ -72,7 +72,7 @@ SDL_Texture* Textures::LoadSurface(SDL_Surface* surface)
 {
 
 	if(std::unique_ptr<SDL_Texture, std::function<void(SDL_Texture *)>>texturePtr(
-			SDL_CreateTextureFromSurface(app->render->renderer, surface),
+			SDL_CreateTextureFromSurface(app->render->renderer.get(), surface),
 			[](SDL_Texture *tex) { if(tex) SDL_DestroyTexture(tex); }
 		);
 		texturePtr != nullptr)

--- a/Game/Source/Textures.cpp
+++ b/Game/Source/Textures.cpp
@@ -70,11 +70,7 @@ SDL_Texture* Textures::Load(const char* path)
 // Translate a surface into a texture
 SDL_Texture* Textures::LoadSurface(SDL_Surface* surface)
 {
-
-	if(std::unique_ptr<SDL_Texture, std::function<void(SDL_Texture *)>>texturePtr(
-			SDL_CreateTextureFromSurface(app->render->renderer.get(), surface),
-			[](SDL_Texture *tex) { if(tex) SDL_DestroyTexture(tex); }
-		);
+	if(auto texturePtr = app->render->LoadTexture(surface);
 		texturePtr != nullptr)
 	{
 		textures.emplace_back(std::move(texturePtr));

--- a/Output/config.xml
+++ b/Output/config.xml
@@ -1,84 +1,51 @@
+<?xml version="1.0"?>
 <config>
 	<app>
 		<title>Game Development Testbed</title>
 		<organization>UPC</organization>
 	</app>
-
-	<renderer>
-		<vsync value="true"/>
-	</renderer>
-
+	<render>
+		<vsync value="false" />
+	</render>
 	<window>
-		<resolution width="1024" height="768" scale="1"/>
-		<fullscreen value="false"/>
-		<borderless value="false"/>
-		<resizable value="false"/>
-		<fullscreen_window value="false"/>
+		<resolution width="1024" height="768" scale="1" />
+		<fullscreen value="false" />
+		<borderless value="false" />
+		<resizable value="false" />
+		<fullscreen_window value="false" />
 	</window>
-
 	<audio>
-		<music volume="128"/>
-		<fx volume="128"/>
+		<music volume="128" />
+		<fx volume="128" />
 	</audio>
-
 	<scene assetpath="Assets/" texturepath="Assets/Animations/" audiopath="Assets/Audio/" fxfolder="Fx/" musicfolder="Music/">
-		<player name="Player" class="Mage" x="44" y="427" renderable="true" maxjumps = "2" jumpimpulse = "5">
-			<physics bodytype="dynamic" gravityscale="1" restitution="0" friction="1" colliderlayers="2"/>				
+		<player name="Player" class="Mage" x="44" y="427" renderable="true" maxjumps="2" jumpimpulse="5">
+			<physics bodytype="dynamic" gravityscale="1" restitution="0" friction="1" colliderlayers="2" />
 			<animationdata>
-				<properties width="128" height="128" pivotx="42" pivoty="85" animstyle="4" animloop="true"/>
-				<animation name="idle" style="4" speed="0.1"/>
+				<properties width="128" height="128" pivotx="42" pivoty="85" animstyle="4" animloop="true" />
+				<animation name="idle" style="4" speed="0.1" />
 				<animation name="walk" style="1" speed="0.2">
 					<collidergroup name="CharacterSensor" class="Dynamic" density="1" sensor="true" width="43" height="58">
-						<chain x="20" y="54" friction="0" points="5,13 14,3 32,4 43,15 42,33 37,40 38,50 34,53 12,53 9,50"/>
-					</collidergroup>	
+						<chain x="20" y="54" friction="0" points="5,13 14,3 32,4 43,15 42,33 37,40 38,50 34,53 12,53 9,50" />
+					</collidergroup>
 					<collidergroup name="Terrain" class="Dynamic" sensor="false" radius="7">
-						<circle name="Ground" friction="1" x="40" y="103"/>
-						<circle name="BottomRight" friction="0" x="51" y="96"/>
-						<circle name="Right" friction="0" x="56" y="75"/>
-						<circle name="TopRight" friction="0" x="52" y="62"/>
-						<circle name="Top" friction="0" x="39" y="57"/>
-						<circle name="TopLeft" friction="0" x="25" y="65"/>
-						<circle name="BottomLeft" friction="0" x="28" y="91"/>
+						<circle name="Ground" friction="1" x="40" y="103" />
+						<circle name="BottomRight" friction="0" x="51" y="96" />
+						<circle name="Right" friction="0" x="56" y="75" />
+						<circle name="TopRight" friction="0" x="52" y="62" />
+						<circle name="Top" friction="0" x="39" y="57" />
+						<circle name="TopLeft" friction="0" x="25" y="65" />
+						<circle name="BottomLeft" friction="0" x="28" y="91" />
 					</collidergroup>
 				</animation>
 			</animationdata>
 		</player>
 	</scene>
-<!---		fixPos	{x=0.799999952 y=2.05999994 }	b2Vec2
-
-<tile id="2" class="Mage">
-	<properties>
-	<property name="Parameters" type="class" propertytype="Animation">
-		<properties>
-		<property name="AnimIteration" propertytype="AnimIteration" value="LOOP_FROM_START"/>
-		<property name="AnimationFrame" type="int" value="1"/>
-		<property name="AnimationName" propertytype="PlayerAnimation" value="Walk"/>
-		<property name="AnimationSpeed" type="float" value="0.2"/>
-		</properties>
-	</property>
-	</properties>
-	<image width="128" height="128" source="../../Animations/Player/Mage/Walk/walk2.png"/>
-	<objectgroup draworder="index" id="3">
-	<object id="2" x="20" y="54" width="43" height="58">
-		<polygon points="5,13 14,3 32,4 43,15 42,33 37,40 37,53 33,56 11,56 8,53"/>
-	</object>
-	</objectgroup>
-	<animation>
-	<frame tileid="2" duration="170"/>
-	<frame tileid="3" duration="170"/>
-	<frame tileid="4" duration="170"/>
-	<frame tileid="5" duration="170"/>
-	<frame tileid="6" duration="170"/>
-	</animation>
-</tile>
--->
 	<fonts>
-		<property path="Assets/Textures/Fonts/"/>
+		<property path="Assets/Textures/Fonts/" />
 	</fonts>
-
 	<map>
-		<mapfolder path="Assets/Maps/Mountain/"/>
-		<mapfile path="Assets/Maps/Mountain/Mountain64.tmx"/>
+		<mapfolder path="Assets/Maps/Mountain/" />
+		<mapfile path="Assets/Maps/Mountain/Mountain64.tmx" />
 	</map>
-	
 </config>


### PR DESCRIPTION
### Render:
- Members are now private. 
- FPS cap implemented. 
- Surface -> Texture is now done in Render.cpp, instead of Texture.cpp.


### Physics:
- Added PIXEL_TO_METERS and METER_TO_PIXELS templates. 
    - They accept either a single number or a struct that has, at least, x and y as parameters.
    - It defaults the type to b2Vec2 (for float) and iPoint (for integer).
    - Type has to be convertible to float or integer, respectively.
- Added iPoint * uint.


### App:
- Added SaveAttributeToConfig function, which can be called by any module to save a single attribute in the **CONFIG** file.
- Added way to pause the game.


### New Keys:
- V: Toggles on/off VSync (Requires a restart for changes to take effect).
- I: Increases the fps cap (Limit 999 fps).
- K: Decreases the fps cap (Limit 10 fps).
- P: Pauses the game (Toggle).
- 0 - 9: Changes Y gravity to that value. Modifiers (Hold while pressing the number):
    - Left Control: Inverses it.
    - Left Shift: Doubles the value.
    - Left Alt: Changes X gravity instead.
- N: Stops physics.
- B: While physics are stopped, do a single step (1 / 60 secs).
- F9: Debug draw.
- F2: Debug draw while a mouse joint is active (Which I broke 4 commits ago, need to redo the joint).
- F5: Save game.
- F6: Load game.
- Escape: Quit game.
- WASD: Move character.
- Space: Jump.